### PR TITLE
fix: Correct recipe serialiser class references

### DIFF
--- a/recipe/1.0/config/packages/message_broker.yaml
+++ b/recipe/1.0/config/packages/message_broker.yaml
@@ -1,7 +1,7 @@
 message_broker:
     inbox:
         # Message type mapping: message_name => PHP class
-        # Used by MessageNameSerializer to translate semantic names to FQN during deserialization
+        # Used by InboxSerializer to translate semantic names to FQN during deserialisation
         message_types:
             # Examples:
             # 'order.placed': 'App\Message\OrderPlaced'

--- a/recipe/1.0/config/packages/messenger.yaml
+++ b/recipe/1.0/config/packages/messenger.yaml
@@ -19,9 +19,10 @@ framework:
 
         transports:
             # Outbox transport - AUTO-MANAGED (auto_setup: true)
+            # No custom serialiser needed — messages are native PHP objects
+            # OutboxToAmqpBridge consumes from this transport
             outbox:
                 dsn: 'doctrine://default?table_name=messenger_outbox&queue_name=outbox'
-                serializer: 'Freyr\MessageBroker\Serializer\MessageNameSerializer'
                 options:
                     auto_setup: true
                 retry_strategy:
@@ -29,14 +30,29 @@ framework:
                   delay: 1000
                   multiplier: 2
 
-
-            # AMQP transport - MANUAL MANAGEMENT (auto_setup: false)
-            # Infrastructure managed by operations/IaC
+            # AMQP publish transport - MANUAL MANAGEMENT (auto_setup: false)
+            # OutboxToAmqpBridge publishes here
+            # Uses OutboxSerializer to translate FQN → semantic name in 'type' header
             amqp:
                 dsn: '%env(MESSENGER_AMQP_DSN)%'
-                serializer: 'Freyr\MessageBroker\Serializer\MessageNameSerializer'
+                serializer: 'Freyr\MessageBroker\Serializer\OutboxSerializer'
                 options:
                     auto_setup: false
+                retry_strategy:
+                  max_retries: 3
+                  delay: 1000
+                  multiplier: 2
+
+            # AMQP consumption transport - MANUAL MANAGEMENT (auto_setup: false)
+            # Uses InboxSerializer to translate semantic name → FQN
+            # Duplicate and rename for each queue your application consumes from
+            amqp_orders:
+                dsn: '%env(MESSENGER_AMQP_DSN)%'
+                serializer: 'Freyr\MessageBroker\Serializer\InboxSerializer'
+                options:
+                    auto_setup: false
+                    queue:
+                        name: 'orders_queue'
                 retry_strategy:
                   max_retries: 3
                   delay: 1000
@@ -55,9 +71,9 @@ framework:
             # 'App\Domain\Event\UserRegistered': outbox
 
             # Inbox messages (consumed from AMQP transports)
-            # Messages are deserialized by MessageNameSerializer into typed objects
+            # Messages are deserialised by InboxSerializer into typed objects
             # DeduplicationMiddleware automatically prevents duplicate processing
-            # Handlers execute synchronously (no routing needed - AMQP transport handles delivery)
+            # Handlers execute synchronously (no routing needed — AMQP transport handles delivery)
             # Example handlers:
             # #[AsMessageHandler]
             # class OrderPlacedHandler { public function __invoke(OrderPlaced $message) {} }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,7 +25,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
             ->arrayNode('message_types')
             ->info(
-                'Map of message_name => PHP class for MessageNameSerializer (e.g., "order.placed" => "App\Message\OrderPlaced")'
+                'Map of message_name => PHP class for InboxSerializer (e.g., "order.placed" => "App\\Message\\OrderPlaced")'
             )
             ->useAttributeAsKey('name')
             ->defaultValue([])

--- a/tests/Unit/Factory/EventBusFactory.php
+++ b/tests/Unit/Factory/EventBusFactory.php
@@ -29,7 +29,7 @@ use Symfony\Component\Serializer\Serializer;
  *
  * Creates a complete Messenger setup programmatically without YAML configuration:
  * - In-memory transports (outbox, amqp)
- * - MessageNameSerializer with custom normalizers
+ * - OutboxSerializer/InboxSerializer with custom normalizers
  * - Routing configuration
  * - Middleware chain
  */

--- a/tests/Unit/InboxFlowTest.php
+++ b/tests/Unit/InboxFlowTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Messenger\Stamp\ReceivedStamp;
  * Tests the full message flow:
  * 1. Publish to outbox transport
  * 2. OutboxToAmqpBridge consumes from outbox and republishes to AMQP
- * 3. Consume from AMQP with MessageNameSerializer (semantic name → FQN)
+ * 3. Consume from AMQP with InboxSerializer (semantic name → FQN)
  * 4. DeduplicationMiddleware checks MessageIdStamp
  * 5. Handler receives typed message
  * 6. Duplicate messages are rejected
@@ -191,7 +191,7 @@ final class InboxFlowTest extends TestCase
         $this->assertEquals(1, $context->deduplicationStore->getDuplicateCount(), 'Duplicate should be detected');
     }
 
-    public function testMessageNameSerializerTranslatesSemanticNameToFqn(): void
+    public function testInboxSerializerTranslatesSemanticNameToFqn(): void
     {
         // Given: Inbox flow setup
         $handledMessages = [];

--- a/tests/Unit/OutboxSerializationTest.php
+++ b/tests/Unit/OutboxSerializationTest.php
@@ -172,7 +172,7 @@ final class OutboxSerializationTest extends TestCase
         $this->assertEquals(
             AmqpTestMessage::class,
             $amqpSerialized['headers']['type'],
-            'AMQP message should have FQN (standard serializer, not MessageNameSerializer)'
+            'AMQP message should have FQN (standard serialiser, not OutboxSerializer)'
         );
 
         $amqpBody = json_decode($amqpSerialized['body'], true);

--- a/tests/Unit/TransportSerializerTest.php
+++ b/tests/Unit/TransportSerializerTest.php
@@ -15,13 +15,13 @@ use PHPUnit\Framework\TestCase;
  * Unit test for transport-specific serializer usage.
  *
  * Tests that:
- * - Outbox transport uses MessageNameSerializer (semantic names in type header)
- * - AMQP transport uses standard Symfony serializer (FQN in type header)
- * - This ensures MessageNameSerializer is only triggered for outbox messages
+ * - Outbox transport uses OutboxSerializer (semantic names in type header)
+ * - AMQP transport uses standard Symfony serialiser (FQN in type header)
+ * - This ensures OutboxSerializer is only triggered for outbox messages
  */
 final class TransportSerializerTest extends TestCase
 {
-    public function testOutboxTransportUsesMessageNameSerializer(): void
+    public function testOutboxTransportUsesOutboxSerializer(): void
     {
         // Given: EventBus with message routed to outbox
         $context = EventBusFactory::createForOutboxTesting(
@@ -38,7 +38,7 @@ final class TransportSerializerTest extends TestCase
         // When: Message is dispatched
         $context->bus->dispatch($message);
 
-        // Then: Message should be serialized with MessageNameSerializer
+        // Then: Message should be serialised with OutboxSerializer
         $serialized = $context->outboxTransport->getLastSerialized();
         $this->assertNotNull($serialized);
 
@@ -46,7 +46,7 @@ final class TransportSerializerTest extends TestCase
         $this->assertEquals(
             'test.message.sent',
             $serialized['headers']['type'],
-            'Outbox transport should use MessageNameSerializer - type header should be semantic name'
+            'Outbox transport should use OutboxSerializer — type header should be semantic name'
         );
 
         $this->assertNotEquals(
@@ -151,7 +151,7 @@ final class TransportSerializerTest extends TestCase
         );
     }
 
-    public function testMessageNameSerializerOnlyTriggeredForOutbox(): void
+    public function testOutboxSerializerOnlyTriggeredForOutbox(): void
     {
         // Given: Multiple messages with MessageName attributes
         $context = EventBusFactory::createForOutboxTesting(


### PR DESCRIPTION
## Summary

The Symfony Flex recipe referenced a non-existent `MessageNameSerializer` class on two transports, causing immediate breakage for anyone installing via Flex. This PR corrects all references to use the actual serialiser classes.

**Severity:** Critical (from architectural review finding #1)

## Changes

- Removed custom serialiser from `outbox` Doctrine transport (uses Symfony default — no semantic name needed at this stage)
- Changed `amqp` publish transport serialiser from `MessageNameSerializer` to `OutboxSerializer`
- Added example `amqp_orders` consumption transport with `InboxSerializer` (was missing from recipe)
- Fixed `Configuration.php` info string referencing the non-existent class
- Fixed `message_broker.yaml` recipe comment
- Updated all test comments and method names to reference actual class names (`OutboxSerializer`/`InboxSerializer`)

## Test Plan

1. All 13 unit tests pass with renamed methods
2. `grep -r "MessageNameSerializer"` confirms no references remain in source, config, recipe, or test code
3. Only acceptable references are in historical documents (CHANGELOG, review, plan)

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)