### PR TITLE
docs: standardize to American English spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING: Stamp-first middleware pattern**
   - `MessageIdStampMiddleware` generates `MessageIdStamp` at dispatch time (previously generated in bridge)
   - New `MessageNameStampMiddleware` extracts semantic name from `#[MessageName]` at dispatch time
-  - Stamps are now the single source of truth for message metadata — serialisers read stamps instead of reflecting on classes
+  - Stamps are now the single source of truth for message metadata — serializers read stamps instead of reflecting on classes
 
 - **BREAKING: Namespace changes** — the following classes moved to `freyr/message-broker-contracts`:
   - `Freyr\MessageBroker\Inbox\MessageIdStamp` → `Freyr\MessageBroker\Contracts\MessageIdStamp`
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING: `OutboxSerializer` replaced by `WireFormatSerializer`**
   - Reads semantic name from `MessageNameStamp` instead of reflecting on `#[MessageName]` attribute
-  - Cleaner separation: serialiser handles wire format only, metadata extraction is middleware's responsibility
+  - Cleaner separation: serializer handles wire format only, metadata extraction is middleware's responsibility
 
 - **BREAKING: Enabled `auto_setup: true` for Doctrine Messenger transports** (outbox, failed)
   - `messenger_outbox` and `messenger_messages` tables are now auto-created by Symfony Messenger
@@ -94,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OutboxPublisherPass` compiler pass — collects services tagged with `message_broker.outbox_publisher` into the middleware's service locator
 - `MessageIdStampMiddleware` — stamps `OutboxMessage` envelopes with `MessageIdStamp` at dispatch time
 - `MessageNameStampMiddleware` — stamps `OutboxMessage` envelopes with `MessageNameStamp` at dispatch time
-- `WireFormatSerializer` — wire format serialiser for AMQP publishing (replaces `OutboxSerializer`)
+- `WireFormatSerializer` — wire format serializer for AMQP publishing (replaces `OutboxSerializer`)
 - Configurable deduplication table name (`deduplication_table_name` in bundle configuration)
 - Comprehensive functional test suite (Outbox flow, Inbox flow, deduplication edge cases, transaction rollback)
 - Phase 1 critical data integrity tests
@@ -107,7 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DeduplicationMiddleware` now `final readonly` with proper logger injection
 - All PHPStan level max errors resolved (119 → 0)
 - ORM entity mapping moved to test directory (not shipped with package)
-- Recipe serialiser class references corrected
+- Recipe serializer class references corrected
 
 ### Removed
 
@@ -124,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Critical: Wrong table name in cleanup command** - `DeduplicationStoreCleanup` command now uses correct table name `message_broker_deduplication` instead of non-existent `deduplication_store`
-- **MessageNameStamp duplication on retry** - Added existence checks before appending `MessageNameStamp` in both serialisers to prevent stamp accumulation during retry/failed scenarios
+- **MessageNameStamp duplication on retry** - Added existence checks before appending `MessageNameStamp` in both serializers to prevent stamp accumulation during retry/failed scenarios
 
 ### Documentation
 
@@ -135,7 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed "Automatic DLQ Routing" feature claim (standard Symfony failed transport is used)
   - Removed `dlq_transport` configuration (never implemented)
 - **Fixed incorrect attribute names** - Changed `#[AmqpExchange]` to correct `#[MessengerTransport]` attribute throughout documentation
-- **Fixed serialiser terminology** - Corrected all references from non-existent `MessageNameSerializer` to actual classes:
+- **Fixed serializer terminology** - Corrected all references from non-existent `MessageNameSerializer` to actual classes:
   - Publishing: `OutboxSerializer`
   - Consuming: `InboxSerializer`
 - **Clarified deduplication mechanism** - Documented that deduplication uses `MessageIdStamp` + PHP class FQN (not `MessageNameStamp`)
@@ -149,7 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Full SQL schemas for all tables
   - Migration examples
   - Cleanup strategies and commands
-  - Performance optimisation notes
+  - Performance optimization notes
   - Transport configuration examples
   - Message flow diagrams
 
@@ -158,7 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Consolidated documentation** - Reduced duplication by creating single source of truth for 3-table architecture in `docs/database-schema.md`
 - **Improved README** - Updated documentation index with links to all architecture docs
 - **Code cleanup** - Applied coding standards and improved code consistency across codebase
-- **British English** - Standardised spelling throughout documentation (serialiser, optimised, customisation)
+- **British English** - Standardized spelling throughout documentation (serializer, optimized, customization)
 
 ### Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Namespace: `Freyr\MessageBroker\*`
 | Configuration & setup | [README.md](README.md) |
 | Database schema & migrations | [docs/database-schema.md](docs/database-schema.md) |
 | Inbox deduplication | [docs/inbox-deduplication.md](docs/inbox-deduplication.md) |
-| Message serialisation | [docs/message-serialization.md](docs/message-serialization.md) |
+| Message serialization | [docs/message-serialization.md](docs/message-serialization.md) |
 | Outbox pattern | [docs/outbox-pattern.md](docs/outbox-pattern.md) |
 | Ordered delivery | [docs/ordered-delivery.md](docs/ordered-delivery.md) |
 | Critical patterns | See `docs/solutions/patterns/` in workspace root |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Inbox and Outbox patterns for Symfony Messenger with transactional guarantees an
 
 | Package | Description |
 |---|---|
-| [freyr/message-broker](https://github.com/freyr/message-broker) | Core bundle — outbox publishing, inbox deduplication, serialisers |
+| [freyr/message-broker](https://github.com/freyr/message-broker) | Core bundle — outbox publishing, inbox deduplication, serializers |
 | [freyr/message-broker-contracts](https://github.com/freyr/message-broker-contracts) | Shared interfaces, stamps, and attributes |
 | [freyr/message-broker-amqp](https://github.com/freyr/message-broker-amqp) | AMQP transport plugin — RabbitMQ publishing, routing, topology management |
 
@@ -203,8 +203,8 @@ See [Ordered Delivery](docs/ordered-delivery.md) for the full guide.
 - [Outbox Pattern](docs/outbox-pattern.md) — transactional event publishing
 - [Ordered Delivery](docs/ordered-delivery.md) — per-aggregate causal ordering with partition keys
 - [Inbox Deduplication](docs/inbox-deduplication.md) — preventing duplicate message processing
-- [Message Serialisation](docs/message-serialization.md) — semantic naming and cross-language compatibility
+- [Message Serialization](docs/message-serialization.md) — semantic naming and cross-language compatibility
 
-## Licence
+## License
 
 MIT

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -17,7 +17,7 @@ These tables are created and managed automatically by Symfony Messenger when `au
    - Standard Symfony Messenger Doctrine transport schema
    - Uses default table name
 
-**First-Run Behaviour:**
+**First-Run Behavior:**
 - Symfony uses `CREATE TABLE IF NOT EXISTS` (idempotent)
 - Tables are created when the worker first polls the transport
 - No manual migration or schema.sql setup required
@@ -43,7 +43,7 @@ The Freyr Message Broker uses a **3-table architecture** for optimal performance
 - ✅ Native AMQP transport consumption (no custom commands)
 - ✅ Middleware-based deduplication (more native to Symfony Messenger)
 - ✅ Transactional guarantees (deduplication + handler in same transaction)
-- ✅ Optimised indexes per use case
+- ✅ Optimized indexes per use case
 - ✅ Independent cleanup policies
 - ✅ Unified failed message monitoring
 - ✅ Flexible: Direct AMQP→Handler or AMQP→Inbox→Handler
@@ -319,7 +319,7 @@ services:
       - { name: 'doctrine.dbal.types', type: 'id_binary' }
 ```
 
-## Index Optimisation
+## Index Optimization
 
 **messenger_outbox (standard):**
 - `idx_queue_name` - Fast filtering by queue
@@ -359,7 +359,7 @@ services:
 ## Performance Considerations
 
 - **Binary ULID:** Chronologically sortable, better index performance than UUID v4
-- **Separate tables:** Independent cleanup, optimised indexes per use case
+- **Separate tables:** Independent cleanup, optimized indexes per use case
 - **SKIP LOCKED:** Native support for horizontal scaling
 - **Transactional deduplication:** Atomic guarantees without distributed locks
 

--- a/docs/message-serialization.md
+++ b/docs/message-serialization.md
@@ -18,7 +18,7 @@ Messages are serialized using semantic, language-agnostic names (`order.placed`)
 **Consuming (AMQP → Inbox):**
 1. Message arrives with `type: order.placed` header
 2. `InboxSerializer` looks up mapping: `order.placed` → `App\Message\OrderPlaced`
-3. Delegates to Symfony's native serialiser for deserialisation
+3. Delegates to Symfony's native serializer for deserialization
 4. Stamps restored from `X-Message-Stamp-*` headers
 5. Result: Typed PHP object for handler
 
@@ -30,7 +30,7 @@ Messages are serialized using semantic, language-agnostic names (`order.placed`)
 
 **Versioning:** Same semantic name can map to different classes per application
 
-**Type safety:** Native Symfony serialisation with full type support
+**Type safety:** Native Symfony serialization with full type support
 
 ## Architecture
 
@@ -45,7 +45,7 @@ AMQP: { type: "order.placed", body: {...}, stamps: X-Message-Stamp-* }
          ↓
 message_types['order.placed'] → App\Message\OrderPlaced
          ↓
-[Symfony Serialiser] → Typed PHP Object
+[Symfony Serializer] → Typed PHP Object
          ↓
 [Handler(OrderPlaced $message)]
 ```
@@ -56,7 +56,7 @@ message_types['order.placed'] → App\Message\OrderPlaced
 - **InboxSerializer** - Consumes from AMQP (semantic name → FQN)
 - **WireFormatSerializer** - Publishes to AMQP (FQN → semantic name)
 - **message_types configuration** - Maps semantic names to PHP classes
-- **Symfony Serialiser** - Native JSON serialisation with normalizers
+- **Symfony Serializer** - Native JSON serialization with normalizers
 - **Stamp headers** - X-Message-Stamp-* for metadata transport
 
 ## Message Format

--- a/recipe/1.0/README.md
+++ b/recipe/1.0/README.md
@@ -31,7 +31,7 @@ bundled console command to create it in the way that best suits your project:
 ### With doctrine/doctrine-migrations-bundle (recommended)
 
 ```bash
-# 1. (Optional) Customise table name in config/packages/message_broker.yaml
+# 1. (Optional) Customize table name in config/packages/message_broker.yaml
 # 2. Generate a migration file
 php bin/console message-broker:setup-deduplication --migration
 
@@ -138,7 +138,7 @@ or use a GitHub repository. See `recipe/TESTING.md` for full details.
 ### Configuration Files
 
 **config/packages/message_broker.yaml:**
-- Message type mappings for inbox (needs user customisation)
+- Message type mappings for inbox (needs user customization)
 - Deduplication table name (defaults to `message_broker_deduplication`)
 - Used by InboxSerializer to translate semantic names to PHP classes
 
@@ -184,10 +184,10 @@ After running `composer require freyr/message-broker`, users need to:
    - `php bin/console messenger:consume outbox -vv` (publish to AMQP)
    - `php bin/console messenger:consume amqp_your_inbox -vv` (consume from AMQP)
 
-## Customisation
+## Customization
 
-Users can customise:
-- Message type mappings in `message_broker.yaml` (inbox deserialisation)
+Users can customize:
+- Message type mappings in `message_broker.yaml` (inbox deserialization)
 - Deduplication table name in `message_broker.yaml`
 - Transport DSNs in `messenger.yaml` (including table names)
 - AMQP connection string in `.env`

--- a/recipe/1.0/config/packages/message_broker.yaml
+++ b/recipe/1.0/config/packages/message_broker.yaml
@@ -1,7 +1,7 @@
 message_broker:
     inbox:
         # Message type mapping: message_name => PHP class
-        # Used by InboxSerializer to translate semantic names to FQN during deserialisation
+        # Used by InboxSerializer to translate semantic names to FQN during deserialization
         message_types:
             # Examples:
             # 'order.placed': 'App\Message\OrderPlaced'

--- a/recipe/1.0/manifest.json
+++ b/recipe/1.0/manifest.json
@@ -22,7 +22,7 @@
         "",
         "  2. Replace <info>your_</> placeholders in <info>config/packages/messenger.yaml</>",
         "",
-        "  3. (Optional) Customise the deduplication table name in <info>config/packages/message_broker.yaml</>:",
+        "  3. (Optional) Customize the deduplication table name in <info>config/packages/message_broker.yaml</>:",
         "     The default is <info>message_broker_deduplication</>.",
         "",
         "  4. Create the deduplication table:",

--- a/recipe/TESTING.md
+++ b/recipe/TESTING.md
@@ -239,7 +239,7 @@ After installation, verify:
 ### Services
 
 - [ ] Bundle registered in `config/bundles.php`
-- [ ] Serialisers registered: `php bin/console debug:container | grep Serializer`
+- [ ] Serializers registered: `php bin/console debug:container | grep Serializer`
 
 ### Messenger
 


### PR DESCRIPTION
## Summary

- Replace all British English spellings with American English across 9 documentation files
- Changes include: serialiser→serializer, behaviour→behavior, optimised→optimized, customise→customize, licence→license, deserialisation→deserialization, standardised→standardized
- Source code already uses American English consistently; only documentation text had British spellings

Fixes #50

## Test plan

- [x] PHPStan: no errors
- [x] ECS: no style issues  
- [x] PHPUnit: all 147 tests pass
- [x] Grep verification: no British spellings remain in documentation files (only internal `todos/` artifacts excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)